### PR TITLE
[#8] 교사용 회원 가입 페이지 추가

### DIFF
--- a/App.js
+++ b/App.js
@@ -3,6 +3,7 @@ import {NavigationContainer} from '@react-navigation/native';
 import {createStackNavigator} from '@react-navigation/stack';
 import MainScreen from './screens/MainScreen';
 import TeacherLoginScreen from './screens/TeacherLoginScreen';
+import TeacherSignUpScreen from "./screens/TeacherSignUpScreen";
 
 const Stack = createStackNavigator();
 
@@ -12,6 +13,7 @@ const App = () => {
             <Stack.Navigator screenOptions={{headerShown: false}}>
                 <Stack.Screen name="Main" component={MainScreen}/>
                 <Stack.Screen name="TeacherLogin" component={TeacherLoginScreen}/>
+                <Stack.Screen name="TeacherSignUp" component={TeacherSignUpScreen}/>
             </Stack.Navigator>
         </NavigationContainer>
     );

--- a/api/config.js
+++ b/api/config.js
@@ -1,0 +1,2 @@
+export const API_SERVER_HOST = 'http://localhost:8080'
+export const TEACHER = `${API_SERVER_HOST}/teachers`

--- a/api/teacherApi.js
+++ b/api/teacherApi.js
@@ -1,0 +1,38 @@
+import axios from 'axios';
+import {TEACHER} from "./config";
+import {Alert} from "react-native";
+
+export const postTeacherSignUp = async (signUpForm, navigation) => {
+        try {
+            const response = await axios.post(TEACHER, signUpForm, {
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+            });
+            Alert.alert('회원가입 성공', '회원가입이 완료되었습니다.');
+            // TODO: 클래스 관리 페이지로 이동
+
+            return response;
+        } catch (error) {
+            if (error.status === 409) {
+                Alert.alert('가입된 회원', '이미 가입된 이메일 주소입니다.\n로그인 페이지로 이동합니다.', [
+                    {
+                        text: '확인',
+                        onPress: () =>
+                            navigation.reset({
+                                index: 1,
+                                routes: [
+                                    {name: 'Main'},
+                                    {name: 'TeacherLogin', params: {email: signUpForm.email}},
+                                ],
+                            })
+                    }
+                ]);
+
+                return;
+            }
+
+            Alert.alert('회원가입 실패', '회원 가입에 실패했습니다.\n잠시 후 다시 시도해 주세요.');
+        }
+    }
+;

--- a/components/BackButton.js
+++ b/components/BackButton.js
@@ -21,13 +21,14 @@ const BackButton = () => {
 const styles = StyleSheet.create({
     container: {
         position: 'absolute',
-        top: 10,
-        left: 10,
+        top: 20,
+        left: 20,
         padding: 10,
+        marginTop: 50
     },
     image: {
-        width: 24,
-        height: 24,
+        width: 20,
+        height: 20,
         resizeMode: 'contain',
     },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@react-navigation/native": "^7.0.14",
         "@react-navigation/stack": "^7.1.1",
+        "axios": "^1.7.9",
         "expo": "~52.0.11",
         "expo-status-bar": "~2.0.0",
         "react": "18.3.1",
@@ -4059,6 +4060,31 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/axios": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/babel-core": {
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
@@ -5816,6 +5842,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/fontfaceobserver": {
@@ -8762,6 +8808,12 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
     "node_modules/pump": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@react-navigation/native": "^7.0.14",
     "@react-navigation/stack": "^7.1.1",
+    "axios": "^1.7.9",
     "expo": "~52.0.11",
     "expo-status-bar": "~2.0.0",
     "react": "18.3.1",

--- a/screens/TeacherLoginScreen.js
+++ b/screens/TeacherLoginScreen.js
@@ -1,24 +1,40 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {Image, StyleSheet, Text, TextInput, TouchableOpacity, View} from 'react-native';
 import BackButton from "../components/BackButton";
+import {useNavigation, useRoute} from "@react-navigation/native";
 
 const TeacherLoginScreen = () => {
+    const navigation = useNavigation();
+    const route = useRoute();
+
+    const [email, setEmail] = useState(route.params?.email || '');
+    const [password, setPassword] = useState('');
+
     return (
         <View style={styles.container}>
-            <View style={styles.backButton}>
-                <BackButton/>
-            </View>
+            <BackButton/>
 
             <Image source={require('../assets/main-cloud.png')} style={styles.image}/>
 
-            <TextInput placeholder="이메일 주소를 입력해 주세요." style={styles.input}/>
-            <TextInput placeholder="비밀번호를 입력해 주세요." style={styles.input} secureTextEntry/>
+            <TextInput
+                placeholder="이메일 주소를 입력해 주세요."
+                style={styles.input}
+                value={email}
+                onChangeText={setEmail}
+            />
+
+            <TextInput
+                placeholder="비밀번호를 입력해 주세요."
+                style={styles.input}
+                onChangeText={setPassword}
+                secureTextEntry
+            />
 
             <TouchableOpacity style={styles.loginButton}>
                 <Text style={styles.loginButtonText}>로그인</Text>
             </TouchableOpacity>
 
-            <TouchableOpacity>
+            <TouchableOpacity onPress={() => navigation.navigate('TeacherSignUp')}>
                 <Text style={styles.registerText}>회원 가입</Text>
             </TouchableOpacity>
         </View>
@@ -70,13 +86,7 @@ const styles = StyleSheet.create({
         fontSize: 14,
         color: '#3A4A5E',
         marginTop: 10,
-    },
-    backButton: {
-        position: 'absolute',
-        top: 10,
-        left: 10,
-        padding: 10,
-        marginTop: 50
+        textDecorationLine: 'underline'
     }
 });
 

--- a/screens/TeacherSignUpScreen.js
+++ b/screens/TeacherSignUpScreen.js
@@ -1,0 +1,242 @@
+import React, {useState} from 'react';
+import {Alert, StyleSheet, Text, TextInput, TouchableOpacity, View} from 'react-native';
+import BackButton from '../components/BackButton';
+import {postTeacherSignUp} from "../api/teacherApi";
+import {useNavigation} from "@react-navigation/native";
+
+const TeacherSignUpScreen = () => {
+        const [name, setName] = useState('');
+        const [email, setEmail] = useState('');
+        const [password, setPassword] = useState('');
+        const [passwordError, setPasswordError] = useState('');
+
+        const navigation = useNavigation();
+
+        const handleSignUp = async () => {
+            if (!validate()) {
+                return;
+            }
+
+            const signUpForm = {
+                name,
+                email: `${email}@korea.kr`,
+                password,
+            };
+
+            await postTeacherSignUp(signUpForm, navigation);
+        };
+
+        const validate = () => {
+            if (!name) {
+                Alert.alert('입력 오류', '이름을 입력해 주세요.');
+                return false;
+            }
+            if (!email) {
+                Alert.alert('입력 오류', '이메일 주소를 입력해 주세요.');
+                return false;
+            }
+            if (!password) {
+                Alert.alert('입력 오류', '비밀번호를 입력해 주세요.');
+                return false;
+            }
+            if (passwordError && passwordError !== '적합한 비밀번호') {
+                Alert.alert('입력 오류', '비밀번호가 적합하지 않습니다.');
+                return false;
+            }
+
+            return true;
+        }
+
+        const handlePasswordChange = (text) => {
+            setPassword(text);
+
+            if (text === '') {
+                setPasswordError('');
+                return;
+            }
+
+            const hasSpecialCharacter = /[!@#$%^&*(),.?":{}|<>]/.test(text);
+            const hasAlphabet = /[a-zA-Z]/.test(text);
+            const hasNumber = /\d/.test(text);
+            const isValidLength = text.length >= 8 && text.length <= 20;
+
+            if (!hasSpecialCharacter) {
+                setPasswordError('특수문자를 포함해야 합니다.');
+                return;
+            }
+            if (!hasAlphabet) {
+                setPasswordError('영문자를 포함해야 합니다.');
+                return;
+            }
+            if (!hasNumber) {
+                setPasswordError('숫자를 포함해야 합니다.');
+                return;
+            }
+            if (!isValidLength) {
+                setPasswordError('비밀번호는 8자 이상 20자 이하여야 합니다.');
+                return;
+            }
+
+            setPasswordError('적합한 비밀번호');
+        };
+
+        return (
+            <View style={styles.container}>
+                <View style={styles.header}>
+                    <BackButton/>
+                    <View style={styles.titleContainer}>
+                        <Text style={styles.title}>회원 가입</Text>
+                    </View>
+                </View>
+
+                <View style={styles.content}>
+                    <View style={styles.inputContainer}>
+                        <Text style={styles.label}>이름</Text>
+                        <TextInput
+                            placeholder="이름을 입력해 주세요."
+                            style={styles.input}
+                            value={name}
+                            onChangeText={setName}
+                        />
+                    </View>
+
+                    <View style={styles.inputContainer}>
+                        <Text style={styles.label}>이메일 주소</Text>
+                        <View style={styles.emailRow}>
+                            <TextInput
+                                placeholder="이메일"
+                                style={[styles.input, styles.emailInput]}
+                                value={email}
+                                onChangeText={setEmail}
+                            />
+                            <Text style={styles.emailDomain}>@ korea.kr</Text>
+                        </View>
+                    </View>
+
+                    <View style={styles.inputContainer}>
+                        <Text style={styles.label}>비밀번호</Text>
+                        <TextInput
+                            placeholder="비밀번호를 입력해 주세요."
+                            style={styles.input}
+                            secureTextEntry
+                            value={password}
+                            onChangeText={handlePasswordChange}
+                        />
+                        {passwordError
+                            ? (
+                                passwordError === '적합한 비밀번호'
+                                    ?
+                                    <Text style={styles.rightText}>
+                                        적합한 비밀번호입니다.
+                                    </Text>
+                                    : (
+                                        <Text style={styles.errorText}>{passwordError}</Text>
+                                    )
+                            )
+                            : (
+                                <Text style={styles.hint}>
+                                    *영문, 숫자, 특수문자 포함 8자 이상, 20자 이하로 입력
+                                </Text>)}
+                    </View>
+                </View>
+
+                <TouchableOpacity style={styles.signUpButton} onPress={handleSignUp}>
+                    <Text style={styles.signUpButtonText}>가입하기</Text>
+                </TouchableOpacity>
+            </View>
+        );
+    }
+;
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        backgroundColor: '#FFFFFF',
+        padding: 20,
+    },
+    header: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        borderBottomWidth: 1,
+        borderBottomColor: '#CCCCCC',
+        marginTop: -20,
+        marginBottom: 20,
+        marginLeft: -20,
+    },
+    titleContainer: {
+        flex: 1,
+        alignItems: 'center',
+        marginTop: 5,
+        marginLeft: 10,
+    },
+    content: {
+        flex: 1,
+        justifyContent: 'flex-start',
+    },
+    title: {
+        fontSize: 24,
+        fontWeight: 'bold',
+        color: '#3A4A5E',
+        marginVertical: 20,
+        textAlign: 'center',
+        marginTop: 70,
+    },
+    inputContainer: {
+        marginBottom: 20,
+    },
+    label: {
+        fontSize: 16,
+        color: '#3A4A5E',
+        marginBottom: 8,
+    },
+    input: {
+        width: '100%',
+        padding: 10,
+        borderWidth: 1,
+        borderColor: '#CCCCCC',
+        borderRadius: 10,
+        backgroundColor: '#F9F9F9',
+    },
+    emailRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+    },
+    emailInput: {
+        flex: 1,
+    },
+    emailDomain: {
+        marginLeft: 10,
+        fontSize: 16,
+        color: '#3A4A5E',
+    },
+    hint: {
+        color: 'red',
+        fontSize: 12,
+        marginTop: 5,
+    },
+    errorText: {
+        color: 'red',
+        fontSize: 12,
+        marginTop: 5,
+    },
+    rightText: {
+        color: 'green',
+        fontSize: 12,
+        marginTop: 5,
+    },
+    signUpButton: {
+        width: '100%',
+        paddingVertical: 15,
+        backgroundColor: '#C9E6F0',
+        borderRadius: 15,
+        alignItems: 'center',
+        marginBottom: 20,
+    },
+    signUpButtonText: {
+        fontSize: 16,
+        fontWeight: 'bold',
+        color: '#3A4A5E',
+    },
+});
+
+export default TeacherSignUpScreen;


### PR DESCRIPTION
## resolve #8

## 작업내용
- 레이아웃
- 이름 주소 입력 스페이스
- 이메일 주소 입력 스페이스
- 비밀번호 입력 스페이스
- 뒤로 가기 버튼 적용
- 비밀번호 패턴 유효성 검사
- 가입하기 버튼 터치 시 서버에 요청 전송
- 이메일 주소 중복 유효성 검사
- 이메일 주소 중복 시 로그인 페이지로 리다이렉트

## 참고

### Android
![스크린샷 2024-12-20 오후 5 00 23](https://github.com/user-attachments/assets/03dc9081-5a87-4f57-895e-e9bf4496adfe)

### IOS
![스크린샷 2024-12-20 오후 5 00 58](https://github.com/user-attachments/assets/7afa19b4-c5a3-44fb-8982-c23fe76a6600)