### PR TITLE
[#16] 우리 반 정보 입력 페이지 추가

### DIFF
--- a/App.js
+++ b/App.js
@@ -5,6 +5,7 @@ import MainScreen from './screens/MainScreen';
 import TeacherLoginScreen from './screens/TeacherLoginScreen';
 import TeacherSignUpScreen from './screens/TeacherSignUpScreen';
 import DashboardScreen from "./screens/DashboardScreen";
+import OurClassInfoScreen from "./screens/OurClassInfoScreen";
 
 const Stack = createStackNavigator();
 
@@ -16,6 +17,7 @@ const App = () => {
                 <Stack.Screen name="TeacherLogin" component={TeacherLoginScreen}/>
                 <Stack.Screen name="TeacherSignUp" component={TeacherSignUpScreen}/>
                 <Stack.Screen name="Dashboard" component={DashboardScreen}/>
+                <Stack.Screen name="OurClassInfo" component={OurClassInfoScreen}/>
             </Stack.Navigator>
         </NavigationContainer>
     );

--- a/api/classroomApi.js
+++ b/api/classroomApi.js
@@ -1,0 +1,17 @@
+import axios from 'axios';
+import {Alert} from "react-native";
+import {CLASSROOM} from "./config";
+
+export const submitClassInfo = async (registerClassInfoRequest) => {
+    try {
+        await axios.post(CLASSROOM, registerClassInfoRequest, {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+        // TODO: 단어 불러오기 페이지로 이동
+    } catch (error) {
+        console.error(error);
+        Alert.alert('클래스 코드 생성 실패', '클래스 코드 생성에 실패했습니다.');
+    }
+}

--- a/api/config.js
+++ b/api/config.js
@@ -1,2 +1,4 @@
 export const API_SERVER_HOST = 'http://localhost:8080'
 export const TEACHER = `${API_SERVER_HOST}/teachers`
+export const SCHOOL = `${API_SERVER_HOST}/schools`
+export const CLASSROOM = `${API_SERVER_HOST}/classrooms`

--- a/api/schoolApi.js
+++ b/api/schoolApi.js
@@ -1,0 +1,21 @@
+import axios from 'axios';
+import {Alert} from "react-native";
+import {SCHOOL} from "./config";
+
+export const searchSchools = async (keyword) => {
+    if (!keyword.trim()) {
+        Alert.alert('검색어 입력', '학교 이름을 입력해주세요.');
+        return;
+    }
+
+    try {
+        const response = await axios.get(SCHOOL, {
+            params: {keyword}
+        });
+
+        return response.data;
+    } catch (error) {
+        console.error(error);
+        Alert.alert('검색 실패', '학교 목록을 불러오지 못했습니다.');
+    }
+}

--- a/api/teacherApi.js
+++ b/api/teacherApi.js
@@ -40,7 +40,7 @@ export const postTeacherSignUp = async (signUpForm, navigation) => {
 
         Alert.alert('회원가입 실패', '회원 가입에 실패했습니다.\n잠시 후 다시 시도해 주세요.');
     }
-};
+}
 
 export const postTeacherSignIn = async (signInForm, navigation) => {
     try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "0BSD",
       "dependencies": {
+        "@react-native-picker/picker": "^2.10.2",
         "@react-navigation/native": "^7.0.14",
         "@react-navigation/stack": "^7.1.1",
         "axios": "^1.7.9",
@@ -16,6 +17,7 @@
         "expo-status-bar": "~2.0.0",
         "react": "18.3.1",
         "react-native": "0.76.3",
+        "react-native-dropdown-picker": "^5.4.6",
         "react-native-gesture-handler": "^2.21.2",
         "react-native-reanimated": "^3.16.5",
         "react-native-safe-area-context": "^5.0.0",
@@ -3221,6 +3223,19 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@react-native-picker/picker": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.10.2.tgz",
+      "integrity": "sha512-kr3OvCRwTYjR/OKlb52k4xmQVU7dPRIALqpyiihexdJxEgvc1smnepgqCeM9oXmNSG4YaV5/RSxFlLC5Z/T/Eg==",
+      "license": "MIT",
+      "workspaces": [
+        "example"
+      ],
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -9034,6 +9049,16 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-dropdown-picker": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/react-native-dropdown-picker/-/react-native-dropdown-picker-5.4.6.tgz",
+      "integrity": "sha512-T1XBHbE++M6aRU3wFYw3MvcOuabhWZ29RK/Ivdls2r1ZkZ62iEBZknLUPeVLMX3x6iUxj4Zgr3X2DGlEGXeHsA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-gesture-handler": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@react-native-picker/picker": "^2.10.2",
     "@react-navigation/native": "^7.0.14",
     "@react-navigation/stack": "^7.1.1",
     "axios": "^1.7.9",
@@ -17,6 +18,7 @@
     "expo-status-bar": "~2.0.0",
     "react": "18.3.1",
     "react-native": "0.76.3",
+    "react-native-dropdown-picker": "^5.4.6",
     "react-native-gesture-handler": "^2.21.2",
     "react-native-reanimated": "^3.16.5",
     "react-native-safe-area-context": "^5.0.0",

--- a/screens/DashboardScreen.js
+++ b/screens/DashboardScreen.js
@@ -12,11 +12,11 @@ const DashboardScreen = () => {
     };
 
     const handleAddClass = () => {
-        navigation.navigate('AddClass');
+        navigation.navigate('OurClassInfo');
     };
 
     const handleCreateClassCode = () => {
-        navigation.navigate('CreateClassCode');
+        navigation.navigate('OurClassInfo');
     };
 
     return (

--- a/screens/OurClassInfoScreen.js
+++ b/screens/OurClassInfoScreen.js
@@ -1,0 +1,283 @@
+import React, {useState} from 'react';
+import {Alert, FlatList, Keyboard, StyleSheet, Text, TextInput, TouchableOpacity, View} from 'react-native';
+import DropDownPicker from 'react-native-dropdown-picker';
+import BackButton from '../components/BackButton';
+import {searchSchools} from '../api/schoolApi';
+import {useNavigation} from "@react-navigation/native";
+import {submitClassInfo} from "../api/classroomApi";
+
+const OurClassInfoScreen = () => {
+    const navigation = useNavigation();
+
+    const [keyword, setKeyword] = useState('');
+    const [schoolNames, setSchoolNames] = useState([]);
+    const [showSuggestions, setShowSuggestions] = useState(false);
+
+    const [openGradePicker, setOpenGradePicker] = useState(false);
+    const [selectedGrade, setSelectedGrade] = useState('3');
+    const [gradeItems, setGradeItems] = useState([
+        {label: '1', value: '1'},
+        {label: '2', value: '2'},
+        {label: '3', value: '3'},
+        {label: '4', value: '4'},
+        {label: '5', value: '5'},
+        {label: '6', value: '6'},
+    ]);
+
+    const [classNumber, setClassNumber] = useState('1');
+
+    const handleSearch = async (text) => {
+        setKeyword(text);
+        if (text.trim() === '') {
+            setSchoolNames([]);
+            setShowSuggestions(false);
+
+            return;
+        }
+
+        const result = await searchSchools(text);
+        console.log('학교명 목록: ', result);
+
+        if (result) {
+            setSchoolNames(result);
+            setShowSuggestions(true);
+        } else {
+            setSchoolNames([]);
+            setShowSuggestions(false);
+        }
+    };
+
+    const handleSelectSchool = (school) => {
+        const schoolNameWithoutType = school.replace(/초등학교$/, '');
+        setKeyword(schoolNameWithoutType);
+        setShowSuggestions(false);
+        Keyboard.dismiss();
+    };
+
+    const handleNextStep = async () => {
+        if (!keyword || !selectedGrade || !classNumber) {
+            Alert.alert('오류', '학교명, 학년, 반을 모두 입력해주세요.');
+            return;
+        }
+
+        const payload = {
+            schoolName: keyword + '초등학교',
+            grade: selectedGrade,
+            classNumber,
+        };
+
+        await submitClassInfo(payload);
+    };
+
+    return (
+        <View style={styles.container}>
+            <View style={styles.header}>
+                <BackButton/>
+                <View style={styles.titleContainer}>
+                    <Text style={styles.title}>우리 반 정보</Text>
+                </View>
+            </View>
+
+            <View style={styles.content}>
+                <View style={styles.inputGroup}>
+                    <Text style={styles.label}>학교</Text>
+                    <View style={styles.searchRow}>
+                        <View style={styles.searchInputContainer}>
+                            <TextInput
+                                placeholder="학교 이름"
+                                value={keyword}
+                                onChangeText={handleSearch}
+                                style={styles.searchInput}
+                            />
+                            <TouchableOpacity style={styles.searchButton}>
+                                <Text style={styles.searchButtonText}>🔍</Text>
+                            </TouchableOpacity>
+                        </View>
+                        <Text style={styles.schoolType}>초등학교</Text>
+                    </View>
+                    {showSuggestions && (
+                        <FlatList
+                            data={schoolNames}
+                            keyExtractor={(item, index) => index.toString()}
+                            renderItem={({item}) => (
+                                <TouchableOpacity
+                                    style={styles.suggestionItem}
+                                    onPress={() => handleSelectSchool(item)}
+                                >
+                                    <Text style={styles.suggestionText}>{item}</Text>
+                                </TouchableOpacity>
+                            )}
+                            style={styles.suggestionList}
+                        />
+                    )}
+                </View>
+
+                <View style={styles.inputGroup}>
+                    <Text style={styles.label}>학년, 반</Text>
+                    <View style={styles.gradeRow}>
+                        <View style={styles.dropdownContainer}>
+                            <DropDownPicker
+                                open={openGradePicker}
+                                value={selectedGrade}
+                                items={gradeItems}
+                                setOpen={setOpenGradePicker}
+                                setValue={setSelectedGrade}
+                                setItems={setGradeItems}
+                                placeholder="3"
+                                style={styles.dropdown}
+                                dropDownContainerStyle={styles.dropdownContainer}
+                            />
+                        </View>
+                        <Text style={styles.gradeText}>학년</Text>
+
+                        <TextInput
+                            placeholder="1"
+                            style={styles.gradeInput} r
+                            keyboardType="numeric"
+                            onChangeText={setClassNumber}
+                        />
+                        <Text style={styles.gradeText}>반</Text>
+                    </View>
+                </View>
+            </View>
+
+            <TouchableOpacity style={styles.nextButton} onPress={handleNextStep}>
+                <Text style={styles.nextButtonText}>다음 단계</Text>
+            </TouchableOpacity>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        backgroundColor: '#FFFFFF',
+        padding: 20,
+    },
+    header: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        borderBottomWidth: 1,
+        borderBottomColor: '#CCCCCC',
+        marginTop: -20,
+        marginBottom: 20,
+        marginLeft: -20,
+    },
+    titleContainer: {
+        flex: 1,
+        alignItems: 'center',
+        marginTop: 5,
+        marginLeft: 10,
+    },
+    title: {
+        fontSize: 24,
+        fontWeight: 'bold',
+        color: '#3A4A5E',
+        marginVertical: 20,
+        textAlign: 'center',
+        marginTop: 70,
+    },
+    content: {
+        flex: 1,
+    },
+    inputGroup: {
+        marginBottom: 20,
+    },
+    label: {
+        fontSize: 16,
+        color: '#3A4A5E',
+        marginBottom: 8,
+    },
+    searchRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+    },
+    searchInputContainer: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        borderWidth: 1,
+        borderColor: '#CCCCCC',
+        borderRadius: 10,
+        backgroundColor: '#F9F9F9',
+        paddingHorizontal: 10,
+        flex: 0.5,
+    },
+    searchInput: {
+        flex: 1,
+        paddingVertical: 10,
+    },
+    searchButton: {
+        marginLeft: 10,
+        padding: 10,
+        backgroundColor: '#C9E6F0',
+        borderRadius: 10,
+    },
+    searchButtonText: {
+        fontSize: 16,
+    },
+    schoolType: {
+        marginLeft: 10,
+        fontSize: 16,
+        color: '#3A4A5E',
+    },
+    suggestionList: {
+        marginTop: 10,
+        backgroundColor: '#F9F9F9',
+        borderWidth: 1,
+        borderColor: '#CCCCCC',
+        borderRadius: 10,
+        maxHeight: 150,
+    },
+    suggestionItem: {
+        padding: 10,
+        borderBottomWidth: 1,
+        borderBottomColor: '#EEEEEE',
+    },
+    suggestionText: {
+        fontSize: 16,
+        color: '#3A4A5E',
+    },
+    gradeRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+    },
+    dropdown: {
+        width: 100,
+        borderColor: '#CCCCCC',
+        backgroundColor: '#F9F9F9',
+    },
+    dropdownContainer: {
+        borderColor: '#CCCCCC',
+        maxHeight: 300,
+    },
+    gradeInput: {
+        width: 50,
+        height: 50,
+        padding: 10,
+        borderWidth: 1,
+        borderColor: '#CCCCCC',
+        borderRadius: 10,
+        backgroundColor: '#F9F9F9',
+        textAlign: 'center',
+    },
+    gradeText: {
+        marginLeft: 10,
+        fontSize: 16,
+        color: '#3A4A5E',
+        marginRight: 10,
+    },
+    nextButton: {
+        marginTop: 20,
+        paddingVertical: 15,
+        borderRadius: 10,
+        backgroundColor: '#C9E6F0',
+        alignItems: 'center',
+    },
+    nextButtonText: {
+        fontSize: 16,
+        fontWeight: 'bold',
+        color: '#3A4A5E',
+    },
+});
+
+export default OurClassInfoScreen;


### PR DESCRIPTION
## resolve #16

## 작업내용
- 레이아웃
- 헤더
    - 뒤로 가기 버튼 컴포넌트 적용
    -  타이틀
- 학교 입력
    - 입력 스페이스
    - 서버 데이터를 기반으로 학교명 자동 완성
    - 학교명 선택
- 학년 입력
    - 학년 콤보박스 선택
- 반 입력
- 다음 단계 버튼
    - 서버에 클래스 데이터 전송

## 참고

### Android
![스크린샷 2025-01-01 오후 12 06 05](https://github.com/user-attachments/assets/bc9991d9-a957-47bf-b14f-d19c4e77fbc1)

### IOS
![스크린샷 2025-01-01 오후 12 07 28](https://github.com/user-attachments/assets/dc72fae0-93e9-4ca7-ab5b-0b127362b116)