### PR TITLE
[#22] 학생용 로그인 페이지 추가

### DIFF
--- a/App.js
+++ b/App.js
@@ -8,6 +8,7 @@ import DashboardScreen from "./screens/DashboardScreen";
 import OurClassInfoScreen from "./screens/OurClassInfoScreen";
 import StudentCodeInputScreen from "./screens/StudentCodeInputScreen";
 import StudentLoginScreen from "./screens/StudentLoginScreen";
+import WordListScreen from "./screens/WordListScreen";
 
 const Stack = createStackNavigator();
 
@@ -22,6 +23,7 @@ const App = () => {
                 <Stack.Screen name="OurClassInfo" component={OurClassInfoScreen}/>
                 <Stack.Screen name="StudentCodeInput" component={StudentCodeInputScreen}/>
                 <Stack.Screen name="StudentLogin" component={StudentLoginScreen}/>
+                <Stack.Screen name="WordList" component={WordListScreen}/>
             </Stack.Navigator>
         </NavigationContainer>
     );

--- a/screens/DashboardScreen.js
+++ b/screens/DashboardScreen.js
@@ -108,7 +108,7 @@ const styles = StyleSheet.create({
         flexShrink: 0,
         justifyContent: 'center',
         alignItems: 'center',
-        borderRadius: 15,
+        borderRadius: 20,
         marginRight: -20,
     },
     addButtonImage: {

--- a/screens/MainScreen.js
+++ b/screens/MainScreen.js
@@ -51,7 +51,7 @@ const styles = StyleSheet.create({
         width: '80%',
         paddingVertical: 12,
         backgroundColor: '#C9E6F0',
-        borderRadius: 15,
+        borderRadius: 20,
         alignItems: 'center',
         marginBottom: 12,
     },

--- a/screens/OurClassInfoScreen.js
+++ b/screens/OurClassInfoScreen.js
@@ -132,7 +132,7 @@ const OurClassInfoScreen = () => {
 
                         <TextInput
                             placeholder="1"
-                            style={styles.gradeInput} r
+                            style={styles.classNumberInput} r
                             keyboardType="numeric"
                             onChangeText={setClassNumber}
                         />
@@ -197,7 +197,7 @@ const styles = StyleSheet.create({
         alignItems: 'center',
         borderWidth: 1,
         borderColor: '#CCCCCC',
-        borderRadius: 10,
+        borderRadius: 15,
         backgroundColor: '#F9F9F9',
         paddingHorizontal: 10,
         flex: 0.5,
@@ -242,7 +242,7 @@ const styles = StyleSheet.create({
         alignItems: 'center',
     },
     dropdown: {
-        width: 100,
+        width: 67,
         borderColor: '#CCCCCC',
         backgroundColor: '#F9F9F9',
     },
@@ -250,13 +250,13 @@ const styles = StyleSheet.create({
         borderColor: '#CCCCCC',
         maxHeight: 300,
     },
-    gradeInput: {
-        width: 50,
+    classNumberInput: {
+        width: 67,
         height: 50,
         padding: 10,
         borderWidth: 1,
         borderColor: '#CCCCCC',
-        borderRadius: 10,
+        borderRadius: 15,
         backgroundColor: '#F9F9F9',
         textAlign: 'center',
     },
@@ -269,7 +269,7 @@ const styles = StyleSheet.create({
     nextButton: {
         marginTop: 20,
         paddingVertical: 15,
-        borderRadius: 10,
+        borderRadius: 20,
         backgroundColor: '#C9E6F0',
         alignItems: 'center',
     },

--- a/screens/StudentCodeInputScreen.js
+++ b/screens/StudentCodeInputScreen.js
@@ -73,7 +73,7 @@ const styles = StyleSheet.create({
         width: '80%',
         paddingVertical: 12,
         backgroundColor: '#C9E6F0',
-        borderRadius: 15,
+        borderRadius: 20,
         alignItems: 'center',
     },
     confirmButtonText: {

--- a/screens/StudentLoginScreen.js
+++ b/screens/StudentLoginScreen.js
@@ -1,4 +1,125 @@
+import React, {useState} from 'react';
+import {Image, StyleSheet, Text, TextInput, TouchableOpacity, View} from 'react-native';
+import BackButton from '../components/BackButton';
+import {useRoute} from '@react-navigation/native';
+
 const StudentLoginScreen = () => {
-}
+    const route = useRoute();
+
+    const {grade, classNumber} = route.params?.classInfo || {};
+    const [name, setName] = useState('');
+    const [birthDate, setBirthDate] = useState('');
+    const [errorMessage, setErrorMessage] = useState('');
+
+    const handleLogin = async () => {
+    };
+
+    return (
+        <View style={styles.container}>
+            <BackButton/>
+
+            <View style={styles.titleContainer}>
+                <Image source={require('../assets/flower.png')} style={styles.flowerIcon}/>
+                <Text style={styles.classInfo}>
+                    {grade}학년 {classNumber}반
+                </Text>
+                <Image source={require('../assets/flower.png')} style={styles.flowerIcon}/>
+            </View>
+
+            <View style={styles.inputContainer}>
+                <TextInput
+                    placeholder="이름 예) 김한재"
+                    style={styles.input}
+                    value={name}
+                    onChangeText={(text) => {
+                        setName(text);
+                        setErrorMessage('');
+                    }}
+                />
+            </View>
+
+            <View style={styles.inputContainer}>
+                <TextInput
+                    placeholder="생년월일 예) 140124"
+                    style={styles.input}
+                    value={birthDate}
+                    onChangeText={(text) => {
+                        setBirthDate(text);
+                        setErrorMessage('');
+                    }}
+                    keyboardType="numeric"
+                />
+            </View>
+
+            {errorMessage ? <Text style={styles.errorText}>{errorMessage}</Text> : null}
+
+            <TouchableOpacity style={styles.loginButton} onPress={handleLogin}>
+                <Text style={styles.loginButtonText}>로그인</Text>
+            </TouchableOpacity>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        backgroundColor: '#FFFFFF',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 20,
+    },
+    titleContainer: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        marginBottom: 30,
+    },
+    flowerIcon: {
+        width: 24,
+        height: 24,
+        resizeMode: 'contain',
+        marginHorizontal: 5,
+    },
+    classInfo: {
+        fontSize: 24,
+        fontWeight: '600',
+        fontFamily: 'Pretendard',
+        color: '#2C424C',
+        fontStyle: 'normal',
+    },
+    inputContainer: {
+        width: '100%',
+        marginBottom: 12,
+    },
+    input: {
+        width: '100%',
+        height: 50,
+        borderWidth: 1,
+        borderColor: '#CCCCCC',
+        borderRadius: 15,
+        backgroundColor: '#F9F9F9',
+        paddingHorizontal: 15,
+    },
+    errorText: {
+        color: '#FF4F4F',
+        fontSize: 14,
+        marginBottom: 20,
+        fontWeight: 400,
+        textAlign: 'center',
+        alignSelf: 'flex-start',
+    },
+    loginButton: {
+        width: '100%',
+        paddingVertical: 15,
+        backgroundColor: '#C9E6F0',
+        borderRadius: 20,
+        alignItems: 'center',
+    },
+    loginButtonText: {
+        fontSize: 16,
+        fontWeight: 'bold',
+        color: '#3A4A5E',
+    },
+});
 
 export default StudentLoginScreen;

--- a/screens/TeacherLoginScreen.js
+++ b/screens/TeacherLoginScreen.js
@@ -109,7 +109,7 @@ const styles = StyleSheet.create({
         width: '80%',
         paddingVertical: 12,
         backgroundColor: '#C9E6F0',
-        borderRadius: 15,
+        borderRadius: 20,
         alignItems: 'center',
         marginBottom: 12,
     },

--- a/screens/TeacherSignUpScreen.js
+++ b/screens/TeacherSignUpScreen.js
@@ -235,7 +235,7 @@ const styles = StyleSheet.create({
         padding: 10,
         borderWidth: 1,
         borderColor: '#CCCCCC',
-        borderRadius: 10,
+        borderRadius: 15,
         backgroundColor: '#F9F9F9',
     },
     emailRow: {
@@ -269,7 +269,7 @@ const styles = StyleSheet.create({
         width: '100%',
         paddingVertical: 15,
         backgroundColor: '#C9E6F0',
-        borderRadius: 15,
+        borderRadius: 20,
         alignItems: 'center',
         marginBottom: 20,
     },

--- a/screens/WordListScreen.js
+++ b/screens/WordListScreen.js
@@ -1,0 +1,4 @@
+const WordListScreen = () => {
+}
+
+export default WordListScreen;


### PR DESCRIPTION
## resolve #22

## 작업내용
-  헤더
    -  뒤로 가기 버튼 컴포넌트 적용
-  레이아웃
-  타이틀
    -  이미지
    -  문구(학년, 반 정보)
-  이름 입력 스페이스
-  비밀번호 입력 스페이스
-  로그인 버튼

## 참고

### Android
![스크린샷 2025-01-05 오후 5 01 44](https://github.com/user-attachments/assets/4ac5a93e-f398-4b73-885c-03576e0b1140)

### IOS
![스크린샷 2025-01-05 오후 5 02 22](https://github.com/user-attachments/assets/a9f71e5c-3717-404b-8b4e-f93995666b92)