### PR TITLE
[#28] 우리 반 정보 페이지의 작업을 이후 작업으로부터 분리

### DIFF
--- a/api/classroomApi.js
+++ b/api/classroomApi.js
@@ -2,16 +2,35 @@ import axios from 'axios';
 import {Alert} from "react-native";
 import {CLASSROOM} from "./config";
 
-export const postSubmitClassInfo = async (registerClassInfoRequest) => {
+export const postSubmitClassInfo = async (registerClassInfoRequest, navigation) => {
     try {
         await axios.post(CLASSROOM, registerClassInfoRequest, {
             headers: {
                 'Content-Type': 'application/json',
             },
         });
-        // TODO: 단어 불러오기 페이지로 이동
+
+        Alert.alert('클래스 등록', '클래스가 등록되었습니다.', [
+            {
+                text: '확인',
+                onPress: () => navigation.goBack()
+            }
+        ]);
     } catch (error) {
         console.error(error);
+
+        if (error.status === 409) {
+            Alert.alert('등록된 클래스', '이미 등록된 클래스입니다.\n클래스 목록에서 단어장을 수정해 주세요.', [
+                {
+                    text: '확인',
+                    onPress: () =>
+                        navigation.goBack()
+                }
+            ]);
+
+            return;
+        }
+
         Alert.alert('클래스 코드 생성 실패', '클래스 코드 생성에 실패했습니다.');
     }
 }

--- a/screens/OurClassInfoScreen.js
+++ b/screens/OurClassInfoScreen.js
@@ -66,7 +66,7 @@ const OurClassInfoScreen = () => {
             classNumber,
         };
 
-        await postSubmitClassInfo(payload);
+        await postSubmitClassInfo(payload, navigation);
     };
 
     return (
@@ -142,7 +142,7 @@ const OurClassInfoScreen = () => {
             </View>
 
             <TouchableOpacity style={styles.nextButton} onPress={handleNextStep}>
-                <Text style={styles.nextButtonText}>다음 단계</Text>
+                <Text style={styles.nextButtonText}>확인</Text>
             </TouchableOpacity>
         </View>
     );


### PR DESCRIPTION
## resolve #28

## 작업내용
- 다음 단계 버튼을 확인 버튼으로 변경
- 중복 클래스 등록 시 예외 모달
- 대시보드 페이지로 이동